### PR TITLE
Added More API Calls for Entries and Drivers

### DIFF
--- a/database/driver.js
+++ b/database/driver.js
@@ -1,0 +1,55 @@
+var Airtable = require('airtable')
+var base = Airtable.base(process.env.AIRTABLE_BASE);
+
+
+var DriverTable = function () {};
+
+DriverTable.prototype.createDriver = function(entryID, driver, cb){
+    //set the team for the entry
+    driver.Entry = entryID
+    base('Driver').create(driver, function(err, record) {
+        if (err) { console.error(err); cb(err, null); }
+        console.log(`Driver created: record.getId()`);
+        cb(null, record);
+    });
+}
+
+DriverTable.prototype.findByEntry = function (entryID, cb){
+    //just send in the AirTable record ID for the team
+    console.log(`Finding entries for entry with ID: ${entryID}`);
+    var drivers = []
+    base('Driver').select({
+        filterByFormula: `{EntryID} = '${entryID}'`
+    }).eachPage(function page(records, fetchNextPage){
+        records.forEach(function(record) {
+            console.log('Retrieved', record.get('EntryID'));
+            drivers.push(record);
+        });
+        fetchNextPage();
+    }, function done(err){
+        if(err){ console.error(err); cb(err); }
+
+        cb(null, drivers);
+    });
+}
+
+DriverTable.prototype.findByTeam = function (teamID, cb){
+    //just send in the AirTable record ID for the team
+    console.log(`Finding entries for team with ID: ${teamID}`);
+    var drivers = []
+    base('Driver').select({
+        filterByFormula: `{TeamID} = '${teamID}'`
+    }).eachPage(function page(records, fetchNextPage){
+        records.forEach(function(record) {
+            console.log('Retrieved', record.get('EntryID'));
+            drivers.push(record);
+        });
+        fetchNextPage();
+    }, function done(err){
+        if(err){ console.error(err); cb(err); }
+
+        cb(null, drivers);
+    });
+}
+
+module.exports = new DriverTable();

--- a/database/entry.js
+++ b/database/entry.js
@@ -1,0 +1,46 @@
+var Airtable = require('airtable')
+var base = Airtable.base(process.env.AIRTABLE_BASE);
+
+
+var EntryTable = function () {};
+
+EntryTable.prototype.findByTeam = function (teamID, cb){
+    //just send in the AirTable record ID for the team
+    console.log(`Finding entries for team with ID: ${teamID}`);
+    var entries = []
+    base('Entry').select({
+        filterByFormula: `{TeamID} = '${teamID}'`
+    }).eachPage(function page(records, fetchNextPage){
+        records.forEach(function(record) {
+            console.log('Retrieved', record.get('EntryID'));
+            entries.push(record);
+        });
+        fetchNextPage();
+    }, function done(err){
+        if(err){ console.error(err); cb(err); }
+
+        cb(null, entries);
+    });
+}
+
+EntryTable.prototype.findEntryByID = function (entryID, cb){
+    //just send in the AirTable record ID for the team
+    console.log(`Finding entry ID: ${entryID}`);
+    base('Entry').find(entryID, function(err, record) {
+        if (err) { console.error(err); cb(err, null); }
+        console.log(record);
+        cb(null, record);
+    });
+}
+
+EntryTable.prototype.createEntry = function(teamID, entry, cb){
+    //set the team for the entry
+    entry.Team = teamID
+    base('Entry').create(entry, function(err, record) {
+        if (err) { console.error(err); cb(err, null); }
+        console.log(`Entry created: record.getId()`);
+        cb(null, record);
+    });
+}
+
+module.exports = new EntryTable();

--- a/routes/team.js
+++ b/routes/team.js
@@ -1,6 +1,8 @@
 var express = require('express');
 var router = express.Router();
 var TeamTable = require('../database/team');
+var EntryTable = require('../database/entry');
+var DriverTable = require('../database/driver');
 
 router.get('/:id', function(req, res) {
     let teamId = req.params.id;
@@ -32,5 +34,68 @@ router.get('/', function(req, res) {
         res.status(200).send(record);
     })
 });
+
+//Team Entries
+router.get('/:id/entry', function(req, res) {
+    let teamId = req.params.id;
+    EntryTable.findByTeam(teamId, function(err, records){
+        if(err){
+            console.log(`Error is ${err}`)
+            console.error(err);
+            //send back error response
+            throw err;
+        }
+        res.status(200).send(records);
+    })
+});
+
+router.post('/:id/entry', function(req, res){
+    EntryTable.createEntry(req.params.id, req.body, function(err, record){
+        if(err){
+            //send back error response
+            throw err;
+        }
+        res.status(200).send(record);
+    })
+});
+
+//Entry Drivers
+router.get('/:teamId/entry/:entryId/drivers', function(req, res) {
+    let entryId = req.params.entryId;
+    DriverTable.findByEntry(entryId, function(err, records){
+        if(err){
+            console.log(`Error is ${err}`)
+            console.error(err);
+            //send back error response
+            throw err;
+        }
+        res.status(200).send(records);
+    })
+});
+
+router.post('/:teamId/entry/:entryId/drivers', function(req, res){
+    DriverTable.createEntry(req.params.entryId, req.body, function(err, record){
+        if(err){
+            //send back error response
+            throw err;
+        }
+        res.status(200).send(record);
+    })
+});
+
+//Team Drivers
+router.get('/:teamId/drivers', function(req, res) {
+    let teamId = req.params.teamId;
+    DriverTable.findByTeam(teamId, function(err, records){
+        if(err){
+            console.log(`Error is ${err}`)
+            console.error(err);
+            //send back error response
+            throw err;
+        }
+        res.status(200).send(records);
+    })
+});
+
 
 module.exports = router;


### PR DESCRIPTION
I tested the GET methods for these to make sure they worked. I have not tested the POST methods to create these in the database.

Added:
Get /api/team/:id/entry - gets teams entry records
Post /api/team/:id/entry - creates a new entry record for the team

Get /api/team/:teamId/entry/:entryId/drivers - gets drivers for a specific entry, team isn't really used
Post /api/team/:teamId/entry/:entryId/drivers - should create a new driver and link it to the entry

Get /api/team/:teamId/drivers - gets the drivers assigned to a team through the entry records

I had to add a bunch of extra fields in the database tables. It turns out it is hard to look up things by a linked record ID, so now there is a lookup field that looks up the record's ID as a separate field. Really dumb.