### PR TITLE
switch to hash URLs to help with linking not always going back to the server

### DIFF
--- a/src/app/routing/app-routing.module.ts
+++ b/src/app/routing/app-routing.module.ts
@@ -22,7 +22,7 @@ const routes: Routes = [
 
 @NgModule({
 	imports: [
-		RouterModule.forRoot(routes)
+		RouterModule.forRoot(routes, {useHash: true})
 	],
 	exports: [RouterModule]
 } )


### PR DESCRIPTION
URLs look a little ugly since everything that should route with Angular will have start with "#" but it helps with every request not redirecting back to the server and should allow us to hit refresh and back/forward buttons in browser.